### PR TITLE
Pass common.Address around instead of a reference

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -20,15 +20,33 @@ func ErrorResponseHandler(c *fiber.Ctx, err error, status int) error {
 	})
 }
 
-func GetUserEthAddr(c *fiber.Ctx) *common.Address {
+const ethereumAddressClaimName = "ethereum_address"
+
+var zeroAddr common.Address
+
+// GetUserEthAddr returns the Ethereum address in the JWT provided for the current request.
+// If no address is found then this function returns a Fiber error that can be safely returned
+// to the client.
+func GetUserEthAddr(c *fiber.Ctx) (common.Address, error) {
+	// If the Fiber middleware runs then these are safe.
 	token := c.Locals("user").(*jwt.Token)
 	claims := token.Claims.(jwt.MapClaims)
-	ethAddr, ok := claims["ethereum_address"].(string)
-	if !ok || !common.IsHexAddress(ethAddr) {
-		return nil
+
+	addrClaim, ok := claims[ethereumAddressClaimName]
+	if !ok {
+		return zeroAddr, fiber.NewError(fiber.StatusUnauthorized, "No Ethereum address claim found.")
 	}
-	e := common.HexToAddress(ethAddr)
-	return &e
+
+	addrString, ok := addrClaim.(string)
+	if !ok {
+		return zeroAddr, fiber.NewError(fiber.StatusUnauthorized, "Ethereum address claim is not a string.")
+	}
+
+	if !common.IsHexAddress(addrString) {
+		return zeroAddr, fiber.NewError(fiber.StatusUnauthorized, "Ethereum address claim is not a valid.")
+	}
+
+	return common.HexToAddress(addrString), nil
 }
 
 // ErrorHandler custom handler to log recovered errors using our logger and return json instead of string

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -43,7 +43,7 @@ func GetUserEthAddr(c *fiber.Ctx) (common.Address, error) {
 	}
 
 	if !common.IsHexAddress(addrString) {
-		return zeroAddr, fiber.NewError(fiber.StatusUnauthorized, "Ethereum address claim is not a valid.")
+		return zeroAddr, fiber.NewError(fiber.StatusUnauthorized, "Ethereum address claim is not a valid hex address.")
 	}
 
 	return common.HexToAddress(addrString), nil

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -28,21 +28,35 @@ func TestGetUserEthAddr(t *testing.T) {
 	tests := []struct {
 		name         string
 		tokenClaims  jwt.MapClaims
-		expectedAddr *common.Address
-		expectingNil bool
+		expectedAddr common.Address
+		expectingErr bool
 	}{
 		{
 			name: "Token With Ethereum Address",
 			tokenClaims: jwt.MapClaims{
 				"ethereum_address": "0x20Ca3bE69a8B95D3093383375F0473A8c6341727",
 			},
-			expectedAddr: &common.Address{0x20, 0xca, 0x3b, 0xe6, 0x9a, 0x8b, 0x95, 0xd3, 0x09, 0x33, 0x83, 0x37, 0x5f, 0x04, 0x73, 0xa8, 0xc6, 0x34, 0x17, 0x27},
-			expectingNil: false,
+			expectedAddr: common.HexToAddress("0x20Ca3bE69a8B95D3093383375F0473A8c6341727"),
+			expectingErr: false,
+		},
+		{
+			name: "Token with Ethereum address claim, wrong type",
+			tokenClaims: jwt.MapClaims{
+				"ethereum_address": 5,
+			},
+			expectingErr: true,
+		},
+		{
+			name: "Token with Ethereum address claim, string that isn't a Hex address",
+			tokenClaims: jwt.MapClaims{
+				"ethereum_address": "k5",
+			},
+			expectingErr: true,
 		},
 		{
 			name:         "Token Without Ethereum Address",
 			tokenClaims:  jwt.MapClaims{},
-			expectingNil: true,
+			expectingErr: true,
 		},
 	}
 
@@ -53,12 +67,12 @@ func TestGetUserEthAddr(t *testing.T) {
 			}
 			ctx.Locals("user", token)
 
-			result := GetUserEthAddr(ctx)
+			result, err := GetUserEthAddr(ctx)
 
-			if tc.expectingNil {
-				assert.Nil(t, result)
+			if tc.expectingErr {
+				assert.Error(t, err)
 			} else {
-				assert.NotNil(t, result)
+				assert.NoError(t, err)
 				assert.Equal(t, tc.expectedAddr, result)
 			}
 		})


### PR DESCRIPTION
The reference is a vestigial thing, from when the token wasn't required to have an address. All test more failure modes, in case Dex goes insane.