### PR TITLE
ex-3726-token-exchange-return-403-for-missing-perm

### DIFF
--- a/internal/controllers/token_exchange.go
+++ b/internal/controllers/token_exchange.go
@@ -268,12 +268,12 @@ func (t *TokenExchangeController) evaluateSacdDoc(c *fiber.Ctx, record *cloudeve
 
 	if err := evaluateCloudEvents(cloudEvtGrants, tokenReq); err != nil {
 		logger.Err(err).Msg("failed to validate cloudevents agreement")
-		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+		return fiber.NewError(fiber.StatusForbidden, err.Error())
 	}
 
 	if err := evaluatePermissions(userPermGrants, tokenReq); err != nil {
 		logger.Err(err).Msg("failed to evaluate permissions agreement")
-		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+		return fiber.NewError(fiber.StatusForbidden, err.Error())
 	}
 	// If we get here, all permission and attestation claims are valid
 	return t.createAndReturnToken(c, tokenReq)

--- a/internal/controllers/token_exchange_test.go
+++ b/internal/controllers/token_exchange_test.go
@@ -376,7 +376,7 @@ func TestTokenExchangeController_ExchangeToken(t *testing.T) {
 				mockipfs.EXPECT().Fetch(gomock.Any(), gomock.Any()).Return(ipfsBytes, nil)
 				mockSacd.EXPECT().CurrentPermissionRecord(nil, common.HexToAddress("0x90C4D6113Ec88dd4BDf12f26DB2b3998fd13A144"), big.NewInt(123), userEthAddr).Return(emptyPermRecord, nil)
 			},
-			expectedCode: fiber.StatusBadRequest,
+			expectedCode: fiber.StatusForbidden,
 		},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
- when an address lacks an old-style permission, return 403 (forbidden) rather than 400
- change an error from `evaluateCloudEvents` and `evaluatePermissions` to also return 403 because if we are failing here it is because of a missing perm