### PR TITLE
feat(access): account-owner self-grant for account-level assets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ VERSION   := $(shell git describe --tags || echo "v0.0.0")
 VER_CUT   := $(shell echo $(VERSION) | cut -c2-)
 
 # Dependency versions
-GOLANGCI_VERSION   = latest
+GOLANGCI_VERSION   = v2.12.1
 PROTOC_VERSION		= 31.1
 
 

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ tools: tools-golangci-lint tools-protoc ## install all tools
 
 tools-golangci-lint: ## install golangci-lint
 	@mkdir -p $(PATHINSTBIN)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | BINARY=golangci-lint bash -s -- ${GOLANGCI_VERSION}
+	GOBIN=$(PATHINSTBIN) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${GOLANGCI_VERSION}
 
 tools-protoc: ## install protoc
 	@mkdir -p $(PATHINSTBIN)

--- a/internal/services/access/access.go
+++ b/internal/services/access/access.go
@@ -82,6 +82,14 @@ func NewAccessService(ipfsService IPFSClient,
 }
 
 func (s *Service) ValidateAccess(ctx context.Context, accessReq *AccessRequest, ethAddr common.Address) error {
+	// An account-level asset is a wallet address: when the requester is that
+	// wallet, there is no grantor/grantee relationship to validate, so the
+	// requested permissions are granted outright. Mirrors the vehicle owner
+	// auto-grant in the legacy bits path (sacdproxy.GetPermissions).
+	if accessReq.Asset.IsAccountLevel() && accessReq.Asset.GetContractAddress() == ethAddr {
+		return nil
+	}
+
 	err := s.ValidateAccessViaSourceDoc(ctx, accessReq, ethAddr)
 	if err != nil {
 		if len(accessReq.EventFilters) != 0 {

--- a/internal/services/access/access_test.go
+++ b/internal/services/access/access_test.go
@@ -609,7 +609,7 @@ func TestAccessService_ValidateAccess_WithoutAsset_WithoutTemplateId(t *testing.
 	}{
 		{
 			name:    "valid request with single privilege and no SACD document or event filters",
-			ethAddr: devLicenseAddr,
+			ethAddr: userEthAddr,
 			accessRequest: &AccessRequest{
 				Asset: models.EthrAsset{
 					EthrDID: cloudevent.EthrDID{
@@ -620,9 +620,9 @@ func TestAccessService_ValidateAccess_WithoutAsset_WithoutTemplateId(t *testing.
 				Permissions: []string{tokenclaims.PrivilegeIDToName[4]},
 			},
 			mockSetup: func(*testing.T) {
-				mockSacd.EXPECT().AccountPermissionRecords(gomock.Any(), devLicenseAddr, devLicenseAddr).Return(emptyPermRecord, nil)
+				mockSacd.EXPECT().AccountPermissionRecords(gomock.Any(), devLicenseAddr, userEthAddr).Return(emptyPermRecord, nil)
 				mockipfs.EXPECT().GetValidSacdDoc(gomock.Any(), gomock.Any()).Return(nil, errors.New("no valid doc"))
-				mockSacd.EXPECT().GetAccountPermissions(gomock.Any(), devLicenseAddr, devLicenseAddr, big.NewInt(0b1100000000)).Return(big.NewInt(0b1100000000), nil)
+				mockSacd.EXPECT().GetAccountPermissions(gomock.Any(), devLicenseAddr, userEthAddr, big.NewInt(0b1100000000)).Return(big.NewInt(0b1100000000), nil)
 			}},
 		{
 			name:    "valid request with multiple privileges and no SACD document or event filters",
@@ -857,7 +857,7 @@ func TestAccessService_ValidateAccess_WithoutAsset_WithTemplateId(t *testing.T) 
 	}{
 		{
 			name:    "valid request with single privilege and no SACD document or event filters",
-			ethAddr: devLicenseAddr,
+			ethAddr: userEthAddr,
 			accessRequest: &AccessRequest{
 				Asset: models.EthrAsset{
 					EthrDID: cloudevent.EthrDID{
@@ -868,9 +868,9 @@ func TestAccessService_ValidateAccess_WithoutAsset_WithTemplateId(t *testing.T) 
 				Permissions: []string{tokenclaims.PrivilegeIDToName[4]},
 			},
 			mockSetup: func(*testing.T) {
-				mockSacd.EXPECT().AccountPermissionRecords(gomock.Any(), devLicenseAddr, devLicenseAddr).Return(emptyPermRecord, nil)
+				mockSacd.EXPECT().AccountPermissionRecords(gomock.Any(), devLicenseAddr, userEthAddr).Return(emptyPermRecord, nil)
 				mockipfs.EXPECT().GetValidSacdDoc(gomock.Any(), gomock.Any()).Return(nil, errors.New("no valid doc"))
-				mockSacd.EXPECT().GetAccountPermissions(gomock.Any(), devLicenseAddr, devLicenseAddr, big.NewInt(0b1100000000)).Return(big.NewInt(0b1100000000), nil)
+				mockSacd.EXPECT().GetAccountPermissions(gomock.Any(), devLicenseAddr, userEthAddr, big.NewInt(0b1100000000)).Return(big.NewInt(0b1100000000), nil)
 			}},
 		{
 			name:    "valid request with multiple privileges and no SACD document or event filters",
@@ -1090,4 +1090,61 @@ func makeDid(method string, chainID string, address string, tokenID string) stri
 		return did + ":" + tokenID
 	}
 	return did
+}
+
+func TestAccessService_ValidateAccess_AccountOwnerSelfGrant(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	// No expectations are set on any mock: a self-grant must short-circuit
+	// before touching the SACD contract, IPFS, or the template service.
+	mockSacd := NewMockSACDInterface(mockCtrl)
+	mockTemplate := NewMockTemplate(mockCtrl)
+	mockipfs := NewMockIPFSClient(mockCtrl)
+
+	templateService, err := template.NewTemplateService(mockTemplate, mockipfs, nil)
+	require.NoError(t, err)
+
+	accessService, err := NewAccessService(mockipfs, mockSacd, templateService, nil, contractAddressManufacturer)
+	require.NoError(t, err)
+
+	userEthAddr := common.HexToAddress("0x20Ca3bE69a8B95D3093383375F0473A8c6341727")
+
+	accountAsset := models.EthrAsset{EthrDID: cloudevent.EthrDID{ChainID: 137, ContractAddress: userEthAddr}}
+
+	t.Run("caller wallet matches account asset", func(t *testing.T) {
+		err := accessService.ValidateAccess(t.Context(), &AccessRequest{
+			Asset:       accountAsset,
+			Permissions: []string{tokenclaims.PermissionGetRawData},
+		}, userEthAddr)
+		require.NoError(t, err)
+	})
+
+	t.Run("self-grant covers cloud event filters", func(t *testing.T) {
+		err := accessService.ValidateAccess(t.Context(), &AccessRequest{
+			Asset: accountAsset,
+			EventFilters: []models.EventFilter{
+				{EventType: "dimo.document.driver.license"},
+			},
+		}, userEthAddr)
+		require.NoError(t, err)
+	})
+
+	t.Run("other caller still requires an account permission record", func(t *testing.T) {
+		otherAddr := common.HexToAddress("0x69F5C4D08F6bC8cD29fE5f004d46FB566270868d")
+
+		mockSacd.EXPECT().
+			AccountPermissionRecords(gomock.Any(), userEthAddr, otherAddr).
+			Return(sacd.ISacdPermissionRecord{}, errors.New("no record")).
+			Times(1)
+
+		err := accessService.ValidateAccess(t.Context(), &AccessRequest{
+			Asset:       accountAsset,
+			Permissions: []string{tokenclaims.PermissionGetRawData},
+			EventFilters: []models.EventFilter{
+				{EventType: "dimo.document.driver.license"},
+			},
+		}, otherAddr)
+		require.Error(t, err)
+	})
 }


### PR DESCRIPTION
## What

`ValidateAccess` now grants requested permissions and cloud-event filters outright when the requester's wallet **is** the account-level asset (`did:ethr:<chainId>:<address>`). No grantor/grantee relationship exists to validate in that case.

## Why

Personal (account-subject) documents are landing in DIS with `subject: did:ethr:...`. To read them back through fetch-api, the mobile app exchanges the user's JWT for a token scoped to the user's own account DID. Without this change that exchange requires an on-chain self-referential SACD record (`AccountPermissionRecords(wallet, wallet)`), which no user has and which would be pointless friction — you always control your own account's data.

Mirrors the existing vehicle owner auto-grant in the legacy bits path (`sacdproxy.GetPermissions`).

## Notes

- Non-self callers on account assets are unchanged: SACD source-doc path, then legacy `GetAccountPermissions` fallback.
- Two account-asset test fixtures used the asset wallet itself as the caller while asserting the record-lookup path; they now use a distinct caller so grantee validation stays covered.
- New test: self-grant for permissions + event filters, plus a non-self caller still hitting the record path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)