### PR TITLE
ci: install golangci-lint via go install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ VERSION   := $(shell git describe --tags || echo "v0.0.0")
 VER_CUT   := $(shell echo $(VERSION) | cut -c2-)
 
 # Dependency versions
-GOLANGCI_VERSION   = latest
+GOLANGCI_VERSION   = v2.12.1
 PROTOC_VERSION		= 31.1
 
 

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ tools: tools-golangci-lint tools-protoc ## install all tools
 
 tools-golangci-lint: ## install golangci-lint
 	@mkdir -p $(PATHINSTBIN)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | BINARY=golangci-lint bash -s -- ${GOLANGCI_VERSION}
+	GOBIN=$(PATHINSTBIN) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${GOLANGCI_VERSION}
 
 tools-protoc: ## install protoc
 	@mkdir -p $(PATHINSTBIN)


### PR DESCRIPTION
The curl installer fails checksum verification for both v2.12.2 and v2.12.1 (upstream checksum source broken), failing every CI run at `install-tools` — including main. `go install` builds from the module proxy with its own sumdb verification and needs no release tarballs. Pinned to v2.12.1.

Extracted from #118, which is being closed (the self-grant feature was superseded by SACD-only access), so the CI fix doesn't die with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)